### PR TITLE
RMET-740 Fix: pipelines retry parameter removed

### DIFF
--- a/CI/templates/pipeline_run.js
+++ b/CI/templates/pipeline_run.js
@@ -55,7 +55,6 @@ async function executePipeline(androidAppID, iosAppID, plugin, androidVersion, i
             "DATACENTER": center,
             "MABS": "latest",
             "PLUGIN_NAME": plugin,
-            "RETRY": "1",
             "TAGS": " ",
             "TEST_TYPE": "native",
             "THREADS": thrds,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fix: pipelines retry parameter removed.
With the RETRY parameter we have an error on pipeline when try to run the Mobile UI Testes on Saucelabs, probably it was removed from mobile UI testes.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
references: https://outsystemsrd.atlassian.net/browse/RMET-740
pipelines updated 

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [ ] iOS
- [x] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
