### PR TITLE
RMET-1474 iOS show error when file has no extension

### DIFF
--- a/src/ios/FileViewerErrors.swift
+++ b/src/ios/FileViewerErrors.swift
@@ -14,6 +14,7 @@ enum FileViewerErrors: String, Error {
     case invalidURL = "The URL you are trying to open is malformed"
     case invalidEmptyURL = "Path of the file to open is either null or empty"
     case downloadFailed = "The download failed"
+    case missingFileExtension = "The file has no extension"
 }
 
 extension FileViewerErrors : LocalizedError {

--- a/src/ios/FileViewerPlugin.swift
+++ b/src/ios/FileViewerPlugin.swift
@@ -22,6 +22,10 @@ class FileViewerPlugin {
         
         if let url = urlString {
             if let file = URL.init(string: url) {
+
+                let fileName = file.lastPathComponent
+                guard fileName.contains(".") else { throw FileViewerErrors.missingFileExtension }
+                
                 guard FileManager.default.fileExists(atPath: file.path) else { throw FileViewerErrors.fileDoesNotExist }
                 
                 if let viewController = rootViewController {
@@ -40,7 +44,7 @@ class FileViewerPlugin {
             return completion({ throw FileViewerErrors.invalidURL })
         }
         
-        if let fileUrl = URL(string: url), let viewController = rootViewController {
+        if let fileUrl = URL(string: url.replacingOccurrences(of: " ", with: "%20")), let viewController = rootViewController {
             let fileViewerOpenDocument = FileViewerOpenDocument(viewController: viewController)
             fileViewerOpenDocument.openDocumentFromUrl(url:fileUrl, completion: { (inner: ErrorCompletionHandler) -> Void in
                 do {


### PR DESCRIPTION
## Description
This PR fixes 2 issues:
1) OpenDocument by FilePath doesn't throw an error when file has no extension;
2) OpenDocument by URL doesn't work if URL have spaces;

## Context
This was reported on support case:
https://outsystemsrd.atlassian.net/browse/RMET-1474

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [X] iOS
- [ ] JavaScript

## Tests
Tested on MABS and simulator, using both client's app and File Sample App

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [X] Pull request title follows the format `RNMT-XXXX <title>`
- [X] Code follows code style of this project
- [X] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
