### PR TITLE
RMET-1769 ::: Move Extensions to Main Class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Version 1.0.6]
+### Fixes
+- Moved the plugin's class extensions to the class itself. (https://outsystemsrd.atlassian.net/browse/RMET-1769)
+
 ## [Version 1.0.5]
 ### Fixes
 - Removed hook that adds swift support and added the plugin as dependecy. (https://outsystemsrd.atlassian.net/browse/RMET-1680)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.outsystems.plugins.fileviewer",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "OutSystems Cordova Plugin to provide the functionality of a file viewer to mobile applications.",
   "keywords": [
     "ecosystem:cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<plugin id="com.outsystems.plugins.fileviewer" version="1.0.5" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.outsystems.plugins.fileviewer" version="1.0.6" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
   <name>OSFileViewer</name>
   <description>OutSystems Cordova Plugin to provide the functionality of a file viewer to mobile applications.</description>
   <author>OutSystems Inc</author>

--- a/src/ios/FileViewerErrors.swift
+++ b/src/ios/FileViewerErrors.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum FileViewerErrors: String, Error {
+enum FileViewerErrors: String, Error, LocalizedError {
     case fileDoesNotExist = "The file you are trying to open does not exist"
     case emptyFileName = "No file name or/and extension was provided"
     case couldNotOpenDocument = "Could not open the document"
@@ -15,8 +15,6 @@ enum FileViewerErrors: String, Error {
     case invalidEmptyURL = "Path of the file to open is either null or empty"
     case downloadFailed = "The download failed"
     case missingFileExtension = "The file has no extension"
-}
 
-extension FileViewerErrors : LocalizedError {
     var errorDescription: String? { return NSLocalizedString(rawValue, comment: "") }
 }

--- a/src/ios/FileViewerOpenDocument.swift
+++ b/src/ios/FileViewerOpenDocument.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class FileViewerOpenDocument: NSObject {
+class FileViewerOpenDocument: NSObject, UIDocumentInteractionControllerDelegate {
     
     var documentInteractionController:UIDocumentInteractionController?
     weak var viewController: UIViewController?
@@ -45,17 +45,14 @@ class FileViewerOpenDocument: NSObject {
         self.documentInteractionController?.presentPreview(animated: true)
     }
     
-}
-
-extension FileViewerOpenDocument: UIDocumentInteractionControllerDelegate {
-    //MARK: UIDocumentInteractionControllerDelegate
+    // MARK: - UIDocumentInteractionControllerDelegate
+        
     func documentInteractionControllerViewControllerForPreview(_ controller: UIDocumentInteractionController) -> UIViewController {
         return self.viewController!
     }
-    
 }
 
-extension URL {
+fileprivate extension URL {
     var uti: String {
         return (try? self.resourceValues(forKeys: [.typeIdentifierKey]))?.typeIdentifier ?? "public.data"
     }

--- a/src/ios/FileViewerPreview.swift
+++ b/src/ios/FileViewerPreview.swift
@@ -9,7 +9,7 @@ import Foundation
 import QuickLook
 import AVKit
 
-class FileViewerPreview {
+class FileViewerPreview: QLPreviewControllerDataSource {
     
     lazy var previewItem = NSURL()
     weak var viewController: UIViewController?
@@ -54,15 +54,12 @@ class FileViewerPreview {
             playerViewController.player!.play()
         }
     }
-    
-}
 
-//MARK:- QLPreviewController DataSource
-extension FileViewerPreview: QLPreviewControllerDataSource {
+    // MARK: - QLPreviewController DataSource
     func numberOfPreviewItems(in controller: QLPreviewController) -> Int {
         return 1
     }
-    
+
     func previewController(_ controller: QLPreviewController, previewItemAt index: Int) -> QLPreviewItem {
         return self.previewItem as QLPreviewItem
     }


### PR DESCRIPTION
## Description
Move the plugin's classes extensions to the main class, in order to avoid conflicts when importing these on Objective C code on an edge case where the project's name has special chars on it.

A Sample App build was generated to test the fix. It's available on the following: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=ce969b297ffedd939bba1bd96d29fd9122c0c51d

## Context
https://outsystemsrd.atlassian.net/browse/RMET-1769

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
