### PR TITLE
RMET-4037 ::: iOS ::: Remove `cordova-plugin-add-swift-support` Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Chores
+- (ios) Replace `cordova-plugin-add-swift-support` plugin with the `SwiftVersion` preference (https://outsystemsrd.atlassian.net/browse/RMET-4037).
+
 ## [Version 1.0.7]
 
 ### 07-11-2024

--- a/plugin.xml
+++ b/plugin.xml
@@ -37,9 +37,8 @@
       <feature name="OSFileViewer">
         <param name="ios-package" value="OSFileViewer"/>
       </feature>
+      <preference name="SwiftVersion" value="5" />
     </config-file>
-
-    <dependency id="cordova-plugin-add-swift-support" url="https://github.com/OutSystems/cordova-plugin-add-swift-support.git#2.0.3-OS1"/>
     
     <source-file src="src/ios/OSFileViewer.swift"/>
     <source-file src="src/ios/FileDownloader.swift"/>


### PR DESCRIPTION
## Description
The only thing the plugin needs is the `SwiftVersion`. This is included directly on `plugin.xml`.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-4037

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality not to work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Checklist
- [x] Pull request title follows the format `RMET-XXXX <title>`
- [ ] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
